### PR TITLE
Update test scripts

### DIFF
--- a/InfraDNS/Tests/Acceptance/DNSServer.tests.ps1
+++ b/InfraDNS/Tests/Acceptance/DNSServer.tests.ps1
@@ -5,6 +5,7 @@
 ####################################################################
 
 Import-Module PoshSpec
+Clear-DnsClientCache
 
 Describe 'Web Server E2E' {
     Context 'DNS addressess' {

--- a/InfraDNS/Tests/Integration/DNSServer.tests.ps1
+++ b/InfraDNS/Tests/Integration/DNSServer.tests.ps1
@@ -73,7 +73,7 @@ Describe 'DNS Server' {
         }
 
         It "Should have a CName record for DNS pointing to TestAgent1" {
-            (Get-DnsServerResourceRecord -Name dns -ZoneName contoso.com).RecordData.HostNameAlias | Should match 'TestAgent1.'
+            (Get-DnsServerResourceRecord -Name dns -ZoneName contoso.com -ErrorAction SilentlyContinue).RecordData.HostNameAlias | Should match 'TestAgent1.'
         }
     }
 }


### PR DESCRIPTION
Make sure build server is always checking DNS records from the zone records and never from cache.
Prevent exception in Integration tests.
