### PR TITLE
Fixing typo in Pester It statement

### DIFF
--- a/InfraDNS/Tests/Unit/DNSServer.tests.ps1
+++ b/InfraDNS/Tests/Unit/DNSServer.tests.ps1
@@ -29,7 +29,7 @@ Describe "DNSServer Configuration" {
             (Get-Command DNSServer).IsMetaConfiguration | Should Not be $true
         }
 
-        It "Should use the sDNSServer DSC resource" {
+        It "Should use the xDNSServer DSC resource" {
             (Get-Command DNSServer).Definition | Should Match "xDNSServer"
         }
     }


### PR DESCRIPTION
Line 32 refers to "sDNSServer" instead of "xDNSServer"
